### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,13 +126,13 @@ Changelog
    :target: https://coveralls.io/r/themattrix/python-abduct
 .. |Health| image:: https://landscape.io/github/themattrix/python-abduct/master/landscape.svg
    :target: https://landscape.io/github/themattrix/python-abduct/master
-.. |Version| image:: https://pypip.in/version/abduct/badge.svg?text=version
+.. |Version| image:: https://img.shields.io/pypi/v/abduct.svg?label=version
    :target: https://pypi.python.org/pypi/abduct
-.. |Downloads| image:: https://pypip.in/download/abduct/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/abduct.svg
    :target: https://pypi.python.org/pypi/abduct
-.. |Compatibility| image:: https://pypip.in/py_versions/abduct/badge.svg
+.. |Compatibility| image:: https://img.shields.io/pypi/pyversions/abduct.svg
    :target: https://pypi.python.org/pypi/abduct
-.. |Implementations| image:: https://pypip.in/implementation/abduct/badge.svg
+.. |Implementations| image:: https://img.shields.io/pypi/implementation/abduct.svg
    :target: https://pypi.python.org/pypi/abduct
-.. |Format| image:: https://pypip.in/format/abduct/badge.svg
+.. |Format| image:: https://img.shields.io/pypi/format/abduct.svg
    :target: https://pypi.python.org/pypi/abduct


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20abduct))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `abduct`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.